### PR TITLE
Remove tgz files

### DIFF
--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -29,6 +29,11 @@ function update_obs_service {
   # Workaround because:
   # https://github.com/openSUSE/obs-service-tar_scm/issues/296
   VC_MAILADDR="$CHANGESAUTHOR" osc service dr
+
+  # This looks like node_modules obs service bug, as it puts older node modules in the root folder
+  # even though the good ones are compressed in the obscpio file
+  echo "Removing currently extracted old tgz files..."
+  rm -f ./*.tgz
 }
 
 function create_tarball {


### PR DESCRIPTION
By now, due to some issue with OBS `node_modules`, old tgz version (`react-tostify` in the last one) is put in the OBS package root folder, even though the new version is in the `obscpio` file.
This already made our last submission to OBS got rejected.
Now, this patch will remove old tgz files.

@fabriziosestito knows more or less what I'm talking about XD