### PR TITLE
Allow to continue on first run - no previous tar

### DIFF
--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -23,7 +23,7 @@ function update_obs_service {
   cd $DEST_FOLDER
 
   echo "Removing old tarball: $tarball ..."
-  osc rm -f ./*.tar.*
+  osc rm -f ./*.tar.* | true
 
   echo "Updating the package using obs service..."
   # Workaround because:


### PR DESCRIPTION
This PR prevents the `upload.sh` script from failing on an initial run when the previous package does not exist yet. It attempts to delete the package but will continue when it doesn't manage to delete it.