### PR TITLE
Add support to authenticate through ssh

### DIFF
--- a/oscrc
+++ b/oscrc
@@ -124,4 +124,7 @@ apiurl = https://api.opensuse.org
 # pass =
 # Force using of keyring for this API
 # keyring = 1
+# These two next are required for the new 2FA to IBS
+# sshkey=id_rsa
+# credentials_mgr_class=osc.credentials.TransientCredentialsManager
 trusted_prj=openSUSE:Factory

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -9,6 +9,15 @@ function check_user {
     sed -i "s/# pass =/pass = $OBS_PASS/g" $OSCRC_FILE    
   fi
 
+  if [ -n "$OBS_SSH_KEY" ]; then
+    mkdir -p "$HOME/.ssh"
+    chmod 700 "$HOME/.ssh"
+    printf "%s\n" "$OBS_SSH_KEY" > "$HOME/.ssh/id_rsa_obs"
+    chmod go-rwx "$HOME/.ssh/id_rsa_obs"
+    sed -i "s/# sshkey=id_rsa/sshkey=id_rsa_obs/g" "$OSCRC_FILE"
+    sed -i "s/# credentials_mgr_class=/credentials_mgr_class=/g" "$OSCRC_FILE"
+  fi
+
   # Check if the OSC_API_URL is set
   if [ -z $OSC_API_URL ]; then    
     return 0


### PR DESCRIPTION
This PR should add ssh-based 2fa support to our continuous delivery container used for the premium builds.