### PR TITLE
Fix home reference and install go explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN zypper -n ar https://download.opensuse.org/repositories/openSUSE:/Tools/15.4
     zypper -n ar https://download.opensuse.org/repositories/OBS:/Server:/Unstable/15.4/OBS:Server:Unstable.repo && \
     zypper -n ar https://download.opensuse.org/repositories/devel:/languages:/erlang/15.4/devel:languages:erlang.repo && \
     zypper -n --gpg-auto-import-keys refresh --force --services && \
-    zypper install -y sudo osc tar gzip build vim elixir wget unzip \
+    zypper install -y sudo osc tar gzip build wget unzip vim go elixir \
                       obs-service-obs_scm \
                       obs-service-obs_scm-common \
                       obs-service-recompress \

--- a/scripts/submit.sh
+++ b/scripts/submit.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 source $(dirname $0)/utils.sh
 
-OSCRC_FILE=${OSCRC_FILE:=/root/.config/osc/oscrc}
+OSCRC_FILE=${OSCRC_FILE:=$HOME/.config/osc/oscrc}
 
 # Mandatory parameters set using env varialbes
 # OBS_USER, OBS user

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -4,7 +4,7 @@ source $(dirname $0)/utils.sh
 
 TMP_FOLDER=/tmp
 DEST_FOLDER=/tmp/osc_project
-OSCRC_FILE=${OSCRC_FILE:=/root/.config/osc/oscrc}
+OSCRC_FILE=${OSCRC_FILE:=$HOME/.config/osc/oscrc}
 FOLDER=${FOLDER:=.}
 CHANGESAUTHOR=${CHANGESAUTHOR:=$(git -C $FOLDER log -1 --format='%ae')}
 


### PR DESCRIPTION
[leftover from #12](https://github.com/trento-project/continuous-delivery/pull/13)

Had to reopen the PR because in the meanwhile I renamed the base branch. Also I tested the image. 😉 