### PR TITLE
Pin golang version to 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN zypper -n ar https://download.opensuse.org/repositories/openSUSE:/Tools/15.4
     zypper -n --gpg-auto-import-keys refresh --force --services && \
     zypper install -y build \
                       elixir \
-                      go \
+                      go1.18 \
                       gzip \
                       helm \
                       obs-service-obs_scm \


### PR DESCRIPTION
Pin golang version to 1.18, otherwise, the used golang version doesn't match with the used one in trento-agent.
This generates the next error: https://github.com/trento-project/agent/actions/runs/7970156630/job/21757896426