### PR TITLE
[TRNT-4358] Add license headers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,17 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  linter-license-headers:
+    name: Check license headers
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Check license headers
+        uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
+
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: Build & push container image to GH packages
 on:
   push:

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+header:
+  comment: on-failure
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: SUSE LLC
+    software-name: trento-continuous-delivery
+    content: |
+      SPDX-FileCopyrightText: SUSE LLC
+      SPDX-License-Identifier: Apache-2.0
+  paths-ignore:
+    - "**/*.adoc"
+    - ".github/dependabot.yml"
+    - "LICENSE"
+    - "oscrc"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 FROM opensuse/tumbleweed@sha256:e1e1a652a28384a3cae36938a84371de5e1c3d3a6d811d14caa1dd758366a934
 # ^ `tumbleweed` base image as of 01 Apr 2026
 

--- a/scripts/get_version_from_git.sh
+++ b/scripts/get_version_from_git.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 set -eo pipefail
 
 # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string

--- a/scripts/gh_release_to_obs_changeset.py
+++ b/scripts/gh_release_to_obs_changeset.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+
 import argparse
 import json
 import os

--- a/scripts/gh_release_to_obs_changeset.py
+++ b/scripts/gh_release_to_obs_changeset.py
@@ -3,7 +3,6 @@
 # SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
-
 import argparse
 import json
 import os

--- a/scripts/init_osc_creds.sh
+++ b/scripts/init_osc_creds.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 source $(dirname $0)/utils.sh

--- a/scripts/submit.sh
+++ b/scripts/submit.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 source $(dirname $0)/utils.sh
 
 OSCRC_FILE=${OSCRC_FILE:=$HOME/.config/osc/oscrc}

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 source $(dirname $0)/utils.sh
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+
 function check_user {
   if [ -z $OBS_USER -o -z $OBS_PASS ]; then
     echo "OBS_USER or OBS_PASS not set..."
@@ -19,7 +23,7 @@ function check_user {
   fi
 
   # Check if the OSC_API_URL is set
-  if [ -z $OSC_API_URL ]; then    
+  if [ -z $OSC_API_URL ]; then
     return 0
   else
     sed -i "s|https://api.opensuse.org|$OSC_API_URL|g" $OSCRC_FILE

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -3,7 +3,6 @@
 # SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
-
 function check_user {
   if [ -z $OBS_USER -o -z $OBS_PASS ]; then
     echo "OBS_USER or OBS_PASS not set..."


### PR DESCRIPTION
# Description

In an attempt to follow the REUSE Specification (supported by the Linux Foundation) for managing licence information, this PR adds the recommended `SPDX-FileCopyrightText` and `SPDX-License-Identifier` headers.

Besides, a new linter is added for the CI to check the license headers. 

Related # TRNT-4358

## How was this tested?

License linter.